### PR TITLE
98 fix orm xml missing in openmdx base jar

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -42,9 +42,8 @@
  * This product includes software developed by other organizations as
  * listed in the NOTICE file.
  */
-import org.gradle.kotlin.dsl.*
+import java.io.FileInputStream
 import java.util.*
-import java.io.*
 
 plugins {
 	java
@@ -62,9 +61,9 @@ tasks.clean {
 }
 
 var env = Properties()
-env.load(FileInputStream(File(project.getRootDir(), "build.properties")))
+env.load(FileInputStream(File(project.rootDir, "build.properties")))
 val targetPlatform = JavaVersion.valueOf(env.getProperty("target.platform"))
 
 fun getPlatformDir(): File {
-	return File(project.getRootDir(), "jre-" + targetPlatform);
+	return File(project.rootDir, "jre-$targetPlatform");
 }

--- a/buildSrc/src/main/kotlin/org/openmdx/gradle/ArchiveTask.kt
+++ b/buildSrc/src/main/kotlin/org/openmdx/gradle/ArchiveTask.kt
@@ -44,19 +44,12 @@
  */
 package org.openmdx.gradle
 
-import org.gradle.api.tasks.bundling.Jar
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Internal
-import org.gradle.api.tasks.OutputDirectory
-import org.gradle.api.tasks.InputDirectory
-import org.gradle.api.tasks.InputFiles
-import org.gradle.api.JavaVersion
+import org.gradle.api.tasks.bundling.Jar
 import java.io.File
 import java.io.FileInputStream
-import java.util.Properties
-import java.text.SimpleDateFormat
-import java.util.TimeZone
-import java.util.Date
+import java.util.*
 
 open class ArchiveTask() : Jar() {
 
@@ -67,11 +60,11 @@ open class ArchiveTask() : Jar() {
 		env.load(FileInputStream(File(getProject().getRootDir(), "build.properties")))
 	}
 
-	@Internal var buildDir = getProject().getBuildDir()
-	@Internal var projectDir = getProject().getProjectDir()
-	
+	@Internal var projectDir = project.projectDir
+	@Internal var buildDirAsFile = project.layout.buildDirectory.asFile.get()
+
 	@Input var projectImplementationVersion: String
-	init {		
+	init {
 		projectImplementationVersion = project.getVersion().toString();
 	}
 

--- a/buildSrc/src/main/kotlin/org/openmdx/gradle/GenerateModelsTask.kt
+++ b/buildSrc/src/main/kotlin/org/openmdx/gradle/GenerateModelsTask.kt
@@ -44,45 +44,41 @@
  */
 package org.openmdx.gradle
 
-import org.gradle.api.Project
-import org.gradle.api.Plugin
-import org.gradle.kotlin.dsl.*
-import org.gradle.api.tasks.bundling.Zip
-import org.gradle.api.tasks.Input
-import java.io.File
 import org.gradle.api.tasks.JavaExec
+import org.gradle.kotlin.dsl.withGroovyBuilder
+import java.io.File
 
 open class GenerateModelsTask : JavaExec() {
 
 	init {
-		mainClass.set("org.openmdx.application.mof.externalizer.xmi.XMIExternalizer")	
+		mainClass.set("org.openmdx.application.mof.externalizer.xmi.XMIExternalizer")
 		args = listOf(
 			"--pathMapSymbol=openMDX 2 ~ Core (EMF)",
-			"--pathMapPath=file:" + File(project.getRootDir(), "core/src/model/emf") + "/",
+			"--pathMapPath=file:" + File("${project.rootDir}/core/src/model/emf") + "/",
 			"--pathMapSymbol=openMDX 2 ~ Security (EMF)",
-			"--pathMapPath=file:" + File(project.getRootDir(), "security/src/model/emf") + "/",
+			"--pathMapPath=file:" + File("${project.rootDir}/security/src/model/emf") + "/",
 			"--pathMapSymbol=openMDX 2 ~ Portal (EMF)",
-			"--pathMapPath=file:" + File(project.getRootDir(), "portal/src/model/emf") + "/",
+			"--pathMapPath=file:" + File("${project.rootDir}/portal/src/model/emf") + "/",
 			"--url=file:src/model/emf/models.uml",
 			"--xmi=emf",
-			"--out=" + File(project.getBuildDir(), "generated/sources/model/openmdx-" + project.getName() + "-models.zip"),
-			"--openmdxjdo=" + File(project.getProjectDir(), "src/main/resources"),
+			"--out=" + project.layout.buildDirectory.file("generated/sources/model/openmdx-${project.getName()}-models.zip").get().asFile,
+			"--openmdxjdo=" + File("${project.projectDir}/src/main/resources"),
 			"--markdown-annotations", 
 			"--format=xmi1",
 			"--format=cci2",
 			"--format=jmi1",
 			"--format=jpa3",
 			"--format=mof1",
-			"--format=pimdoc:" + File(project.getProjectDir(), "src/model/doc"),
+			"--format=pimdoc:" + File("${project.projectDir}/src/model/doc"),
 			"%"
 		)
 		doLast {
 			ant.withGroovyBuilder {
 				"zip"(
-					"destfile" to File(project.getBuildDir(), "generated/sources/model/openmdx-" + project.getName() + ".openmdx-xmi.zip")
+					"destfile" to project.layout.buildDirectory.file("generated/sources/model/openmdx-${project.getName()}.openmdx-xmi.zip").get().asFile
 				) {
 					"zipfileset"(
-						"src" to File(project.getBuildDir(), "generated/sources/model/openmdx-" + project.getName() + "-models.zip")
+						"src" to project.layout.buildDirectory.file("generated/sources/model/openmdx-${project.getName()}-models.zip").get().asFile,
 					) {
 						"include"("name" to "**/*.xsd")
 						"include"("name" to "**/*.xml")
@@ -92,33 +88,32 @@ open class GenerateModelsTask : JavaExec() {
 			}
 			ant.withGroovyBuilder {
 				"zip"(
-					"destfile" to File(project.getBuildDir(), "generated/sources/model/openmdx-" + project.getName() + ".openmdx-emf.zip"),
+					"destfile" to project.layout.buildDirectory.file("generated/sources/model/openmdx-${project.getName()}.openmdx-emf.zip").get().asFile,
 					"basedir" to File(project.getProjectDir(), "src/model/emf")
 				)
 			}
 			project.copy {
-				from(project.zipTree(File(project.getBuildDir(), "generated/sources/model/openmdx-" + project.getName() + "-models.zip"))) { 
+				from(project.zipTree(project.layout.buildDirectory.dir("generated/sources/model/openmdx-${project.getName()}-models.zip"))) {
 					include("META-INF/") 
 				}
-				into(File(project.getBuildDir(), "resources/main"))
+				into(project.layout.buildDirectory.dir("resources/main"))
 			}
 			project.copy {
-				from(project.zipTree(File(project.getBuildDir(), "generated/sources/model/openmdx-" + project.getName() + "-models.zip"))) { 
+				from(project.zipTree(project.layout.buildDirectory.dir("generated/sources/model/openmdx-${project.getName()}-models.zip"))) {
 					include("**/*.html") 
 					include("style-sheet.css") 
 					include("*.png") 
 					include("*.svg") 
 				}
-				into(File(project.getBuildDir(), "pimdoc"))
+				into(project.layout.buildDirectory.dir("pimdoc"))
 			}
 			project.copy {
-				from(project.zipTree(File(project.getBuildDir(), "generated/sources/model/openmdx-" + project.getName() + "-models.zip"))) { 
+				from(project.zipTree(project.layout.buildDirectory.dir("generated/sources/model/openmdx-${project.getName()}-models.zip"))) {
 					include("**/*.dot")
 				}
-				into(File(project.getBuildDir(), "generated/sources/dot"))
+				into(project.layout.buildDirectory.dir("generated/sources/dot"))
 			}
 		}
-		
 	}
-	
+
 }

--- a/client/build.gradle.kts
+++ b/client/build.gradle.kts
@@ -43,10 +43,8 @@
  * listed in the NOTICE file.
  */
 
-import org.gradle.kotlin.dsl.*
-import org.w3c.dom.Element
+import java.io.FileInputStream
 import java.util.*
-import java.io.*
 
 plugins {
 	java
@@ -86,7 +84,7 @@ fun getProjectImplementationVersion(): String {
 }
 
 fun getDeliverDir(): File {
-	return File(project.getRootDir(), "jre-" + targetPlatform + "/" + project.getName());
+	return File(project.getRootDir(), "jre-" + targetPlatform + "/" + project.name);
 }
 
 fun touch(file: File) {
@@ -114,7 +112,7 @@ sourceSets {
     main {
         java {
             srcDir("src/main/java")
-            srcDir("$buildDir/generated/sources/java/main")
+            srcDir("${layout.buildDirectory}/generated/sources/java/main")
         }
         resources {
         	srcDir("src/main/resources")
@@ -189,7 +187,7 @@ tasks {
 			":security:openmdx-security.jar"
 		)
 		doFirst {
-			var f = File("$buildDir/resources/main/META-INF/openmdxmof.properties")
+			val f = File("${layout.buildDirectory}/resources/main/META-INF/openmdxmof.properties")
 			touch(f)
 			f.writeText(zipTree(File(getDeliverDir(), "../core/lib/openmdx-base.jar")).matching { include("META-INF/openmdxmof.properties") }.singleFile.readText() )
 			f.appendText(zipTree(File(getDeliverDir(), "../security/lib/openmdx-security.jar")).matching { include("META-INF/openmdxmof.properties") }.singleFile.readText() )
@@ -398,17 +396,17 @@ tasks {
 
 distributions {
     main {
-    	distributionBaseName.set("openmdx-" + getProjectImplementationVersion() + "-" + project.getName() + "-jre-" + targetPlatform)
+    	distributionBaseName.set("openmdx-" + getProjectImplementationVersion() + "-" + project.name + "-jre-" + targetPlatform)
         contents {
         	// client
-        	from(".") { into(project.getName()); include("LICENSE", "*.LICENSE", "NOTICE", "*.properties", "build*.*", "*.xml", "*.kts") }
-            from("src") { into(project.getName() + "/src") }
+        	from(".") { into(project.name); include("LICENSE", "*.LICENSE", "NOTICE", "*.properties", "build*.*", "*.xml", "*.kts") }
+            from("src") { into(project.name + "/src") }
             // etc
-            from("etc") { into(project.getName() + "/etc") }
+            from("etc") { into(project.name + "/etc") }
             // rootDir
             from("..") { include("*.properties", "*.kts" ) }
             // jre-...
-            from("../jre-" + targetPlatform + "/" + project.getName() + "/lib") { into("jre-" + targetPlatform + "/" + project.getName() + "/lib") }
+            from("../jre-" + targetPlatform + "/" + project.name + "/lib") { into("jre-" + targetPlatform + "/" + project.name + "/lib") }
             from("../jre-" + targetPlatform + "/gradle/repo") { into("jre-" + targetPlatform + "/gradle/repo") }
         }
     }

--- a/client/build.gradle.kts
+++ b/client/build.gradle.kts
@@ -112,7 +112,7 @@ sourceSets {
     main {
         java {
             srcDir("src/main/java")
-			srcDir("${buildDir}/generated/sources/java/main")
+			srcDir(layout.buildDirectory.dir("generated/sources/java/main"))
         }
         resources {
         	srcDir("src/main/resources")
@@ -187,7 +187,7 @@ tasks {
 			":security:openmdx-security.jar"
 		)
 		doFirst {
-			var f = File("$buildDir/resources/main/META-INF/openmdxmof.properties")
+			var f = file(layout.buildDirectory.dir("resources/main/META-INF/openmdxmof.properties"))
 			touch(f)
 			f.writeText(zipTree(File(getDeliverDir(), "../core/lib/openmdx-base.jar")).matching { include("META-INF/openmdxmof.properties") }.singleFile.readText() )
 			f.appendText(zipTree(File(getDeliverDir(), "../security/lib/openmdx-security.jar")).matching { include("META-INF/openmdxmof.properties") }.singleFile.readText() )
@@ -241,8 +241,8 @@ tasks {
 	    with(
 	    	copySpec {
 				from(
-					File(buildDir, "classes/java/main"),
-					File(buildDir, "resources/main"),
+					File(buildDirAsFile, "classes/java/main"),
+					File(buildDirAsFile, "resources/main"),
 					"src/main/resources"
 				).include(
 					openmdxClientIncludes
@@ -292,7 +292,7 @@ tasks {
 	    	copySpec {
 				from(
 					"src/main/java",
-					File(buildDir, "generated/sources/java/main")
+					File(buildDirAsFile, "generated/sources/java/main")
 				).include(
 					openmdxClientIncludes
 				).exclude(
@@ -353,8 +353,8 @@ tasks {
 			},
 	    	copySpec {
 				from(
-					File(buildDir, "classes/java/main"),
-					File(buildDir, "resources/main"),
+					File(buildDirAsFile, "classes/java/main"),
+					File(buildDirAsFile, "resources/main"),
 					"src/main/dalvik"
 				).exclude(
 					"META-INF/*/**"
@@ -381,7 +381,7 @@ tasks {
 	    	copySpec {
 				from(
 					"src/main/java",
-					File(buildDir, "generated/sources/java/main"),
+					File(buildDirAsFile, "generated/sources/java/main"),
 					zipTree(File(getDeliverDir(), "../client/lib/openmdx-client-sources.jar"))
 				).include(
 					openmdxDalvikIncludes

--- a/client/build.gradle.kts
+++ b/client/build.gradle.kts
@@ -176,8 +176,8 @@ tasks {
 		"org/omg/primitivetypes/**"
 	)
 
-	named("processResources", Copy::class.java) { duplicatesStrategy = DuplicatesStrategy.WARN }
-	named("processTestResources", Copy::class.java) { duplicatesStrategy = DuplicatesStrategy.WARN }
+	named("processResources", Copy::class.java) { duplicatesStrategy = DuplicatesStrategy.EXCLUDE }
+	named("processTestResources", Copy::class.java) { duplicatesStrategy = DuplicatesStrategy.EXCLUDE }
 
 	test {
 		useJUnitPlatform()
@@ -221,7 +221,7 @@ tasks {
         )
 	}
 	register<org.openmdx.gradle.ArchiveTask>("openmdx-client.jar") {
-	    duplicatesStrategy = DuplicatesStrategy.WARN
+	    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 		dependsOn(
 			":core:openmdx-base.jar",
 			":core:openmdx-system.jar",
@@ -273,7 +273,7 @@ tasks {
 		)
 	}
 	register<org.openmdx.gradle.ArchiveTask>("openmdx-client-sources.jar") {
-	    duplicatesStrategy = DuplicatesStrategy.WARN
+	    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 		dependsOn(
 			":core:openmdx-base-sources.jar",
 			":core:openmdx-system-sources.jar",
@@ -315,7 +315,7 @@ tasks {
 		)
 	}
 	register<org.openmdx.gradle.ArchiveTask>("openmdx-dalvik.jar") {
-	    duplicatesStrategy = DuplicatesStrategy.WARN
+	    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 		dependsOn(
 			"openmdx-client.jar",
 			":client:compileJava",
@@ -366,7 +366,7 @@ tasks {
 	}
 	
 	register<org.openmdx.gradle.ArchiveTask>("openmdx-dalvik-sources.jar") {
-	    duplicatesStrategy = DuplicatesStrategy.WARN
+	    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 		dependsOn(":client:openmdx-client-sources.jar")
 		destinationDirectory.set(File(getDeliverDir(), "lib"))
 		archiveFileName.set("openmdx-dalvik-sources.jar")

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -259,8 +259,8 @@ tasks {
 	)
 	val openmdxSystemExcludes = listOf<String>( )
 
-	named("processResources", Copy::class.java) { duplicatesStrategy = DuplicatesStrategy.WARN }
-	named("processTestResources", Copy::class.java) { duplicatesStrategy = DuplicatesStrategy.WARN }
+	named("processResources", Copy::class.java) { duplicatesStrategy = DuplicatesStrategy.EXCLUDE }
+	named("processTestResources", Copy::class.java) { duplicatesStrategy = DuplicatesStrategy.EXCLUDE }
 	register<org.openmdx.gradle.GenerateModelsTask>("generate-model") {
 	    inputs.dir("${projectDir}/src/model/emf")
 	    inputs.dir("${projectDir}/src/main/resources")
@@ -351,7 +351,7 @@ tasks {
         )
 	}
 	register<org.openmdx.gradle.ArchiveTask>("openmdx-base.jar") {
-	    duplicatesStrategy = DuplicatesStrategy.WARN
+	    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 	    dependsOn(
 	        ":core:compileJava",
 	        ":core:processResources"

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -42,10 +42,8 @@
  * This product includes software developed by other organizations as
  * listed in the NOTICE file.
  */
-import org.gradle.kotlin.dsl.*
-import org.w3c.dom.Element
+import java.io.FileInputStream
 import java.util.*
-import java.io.*
 
 plugins {
 	java
@@ -84,7 +82,7 @@ fun getProjectImplementationVersion(): String {
 }
 
 fun getDeliverDir(): File {
-	return File(project.getRootDir(), "jre-" + targetPlatform + "/" + project.getName());
+	return File(project.getRootDir(), "jre-" + targetPlatform + "/" + project.name);
 }
 
 fun touch(file: File) {
@@ -264,8 +262,8 @@ tasks {
 	register<org.openmdx.gradle.GenerateModelsTask>("generate-model") {
 	    inputs.dir("${projectDir}/src/model/emf")
 	    inputs.dir("${projectDir}/src/main/resources")
-	    outputs.file("${buildDir}/generated/sources/model/openmdx-" + project.getName() + "-models.zip")
-	    outputs.file("${buildDir}/generated/sources/model/openmdx-" + project.getName() + ".openmdx-xmi.zip")
+	    outputs.file("${buildDir}/generated/sources/model/openmdx-" + project.name + "-models.zip")
+	    outputs.file("${buildDir}/generated/sources/model/openmdx-" + project.name + ".openmdx-xmi.zip")
 	    classpath = configurations["openmdxBootstrap"]
 	    doFirst {
 	        project.copy {
@@ -276,7 +274,7 @@ tasks {
 	    doLast {
 	        copy {
 	            from(
-	                zipTree("${buildDir}/generated/sources/model/openmdx-" + project.getName() + "-models.zip")
+	                zipTree("${buildDir}/generated/sources/model/openmdx-" + project.name + "-models.zip")
 	            )
 	            into("$buildDir/generated/sources/java/main")
 	            include(
@@ -285,7 +283,7 @@ tasks {
 	        }
 	        copy {
 	            from(
-	                zipTree("${buildDir}/generated/sources/model/openmdx-" + project.getName() + ".openmdx-xmi.zip")
+	                zipTree("${buildDir}/generated/sources/model/openmdx-" + project.name + ".openmdx-xmi.zip")
 	            )
 	            into("$buildDir/generated/resources/main")
 	            exclude(
@@ -294,7 +292,7 @@ tasks {
 	        }
 	        copy {
 	            from(
-	                zipTree("${buildDir}/generated/sources/model/openmdx-" + project.getName() + "-models.zip")
+	                zipTree("${buildDir}/generated/sources/model/openmdx-" + project.name + "-models.zip")
 	            )
 	            into("$buildDir/generated/resources/main")
 	            include(

--- a/core/src/main/java/org/openmdx/base/rest/spi/Facades.java
+++ b/core/src/main/java/org/openmdx/base/rest/spi/Facades.java
@@ -188,7 +188,7 @@ public class Facades {
     /**
      * Create a query facade for the given object id
      * 
-     * @param ojectId a data object's id
+     * @param objectId a data object's id
      * @param preferringNotFoundException Tells whether a NOT_FOUND exception 
      * shall be thrown rather than returning an empty result set in case a 
      * requested object does not exist.
@@ -198,11 +198,11 @@ public class Facades {
      * @throws ResourceException
      */
     public static Query_2Facade newQuery(
-        Path ojectId,
+        Path objectId,
         boolean preferringNotFoundException
     ) throws ServiceException {
         try {
-            return Query_2Facade.newInstance(ojectId, preferringNotFoundException);
+            return Query_2Facade.newInstance(objectId, preferringNotFoundException);
         } catch (ResourceException exception) {
             throw new ServiceException(exception);
         }
@@ -211,16 +211,16 @@ public class Facades {
     /**
      * Create a query facade for the given object id
      * 
-     * @param ojectId a data object's id
+     * @param objectId a data object's id
      * 
      * @return a query facade for the given object id
      * 
      * @throws ResourceException
      */
     public static Query_2Facade newQuery(
-        Path ojectId
+        Path objectId
     ) throws ServiceException {
-        return newQuery(ojectId, false);
+        return newQuery(objectId, false);
     }
 
 }

--- a/portal/build.gradle.kts
+++ b/portal/build.gradle.kts
@@ -106,7 +106,7 @@ sourceSets {
     main {
         java {
             srcDir("src/main/java")
-            srcDir("$buildDir/generated/sources/java/main")
+            srcDir(layout.buildDirectory.dir("generated/sources/java/main"))
         }
         resources {
         	srcDir("src/main/resources")
@@ -115,7 +115,7 @@ sourceSets {
     test {
         java {
             srcDir("src/test/java")
-            srcDir("$buildDir/generated/sources/java/test")
+            srcDir(layout.buildDirectory.dir("generated/sources/java/test"))
         }
         resources {
         	srcDir("src/test/resources")
@@ -123,7 +123,7 @@ sourceSets {
     }
 }
 
-touch(File(buildDir, "generated/sources/js/portal-all.js"))
+touch(file(layout.buildDirectory.dir("generated/sources/js/portal-all.js")))
 
 tasks {
 	test {
@@ -143,119 +143,122 @@ tasks {
 		)
 	}
 	register<org.openmdx.gradle.GenerateModelsTask>("generate-model") {
-	    inputs.dir("${projectDir}/src/model/emf")
-	    inputs.dir("${projectDir}/src/main/resources")
-	    outputs.file("${buildDir}/generated/sources/model/openmdx-${project.name}-models.zip")
-	    outputs.file("${buildDir}/generated/sources/model/openmdx-${project.name}.openmdx-xmi.zip")
+	    inputs.dir("$projectDir/src/model/emf")
+	    inputs.dir("$projectDir/src/main/resources")
+	    outputs.file(layout.buildDirectory.dir("generated/sources/model/openmdx-${project.name}-models.zip"))
+	    outputs.file(layout.buildDirectory.dir("generated/sources/model/openmdx-${project.name}.openmdx-xmi.zip"))
 	    classpath = configurations["openmdxBootstrap"]
 	    doFirst {
 	    }
 	    doLast {
 	        copy {
 	            from(
-	                zipTree("${buildDir}/generated/sources/model/openmdx-${project.name}-models.zip")
+	                zipTree(layout.buildDirectory.dir("generated/sources/model/openmdx-${project.name}-models.zip"))
 	            )
-	            into("$buildDir/generated/sources/java/main")
+	            into(layout.buildDirectory.dir("generated/sources/java/main"))
 	            include(
 	                "**/*.java"
 	            )
 	        }
 	    }
 	}
+
+	val buildDirAsFile = layout.buildDirectory.asFile.get()
+
 	register<JavaExec>("compress-and-append-prototype") {
 		val fileName = "prototype.js"
-		val dirName = "${projectDir}/src/js/org/prototypejs"
+		val dirName = "$projectDir/src/js/org/prototypejs"
 		classpath = fileTree(
-			File("${projectDir}/etc/yuicompressor", "yuicompressor.jar")
+			File("$projectDir/etc/yuicompressor", "yuicompressor.jar")
 		)
 	    args = listOf(
 	        "--line-break", "1000",
-	        "-o", "$buildDir/generated/sources/js/${fileName}",
-	        "${dirName}/${fileName}"
+	        "-o", "$buildDirAsFile/generated/sources/js/$fileName",
+	        "$dirName/$fileName"
 	    )
 	}
 	register<JavaExec>("compress-and-append-ssf") {
 		val fileName = "ssf.js"
-		val dirName = "${projectDir}/src/js/org/openmdx/portal"
+		val dirName = "$projectDir/src/js/org/openmdx/portal"
 		classpath = fileTree(
-			File("${projectDir}/etc/yuicompressor", "yuicompressor.jar")
+			File("$projectDir/etc/yuicompressor", "yuicompressor.jar")
 		)
 	    args = listOf(
 	        "--line-break", "1000",
-	        "-o", "$buildDir/generated/sources/js/${fileName}",
-	        "${dirName}/${fileName}"
+	        "-o", "$buildDirAsFile/generated/sources/js/$fileName",
+	        "$dirName/$fileName"
 	    )
 	}
 	register<JavaExec>("compress-and-append-calendar") {
 		val fileName = "calendar.js"
-		val dirName = "${projectDir}/src/js/com/dynarch/calendar"
+		val dirName = "$projectDir/src/js/com/dynarch/calendar"
 		classpath = fileTree(
-			File("${projectDir}/etc/yuicompressor", "yuicompressor.jar")
+			File("$projectDir/etc/yuicompressor", "yuicompressor.jar")
 		)
 	    args = listOf(
 	        "--line-break", "1000",
-	        "-o", "$buildDir/generated/sources/js/${fileName}",
-	        "${dirName}/${fileName}"
+	        "-o", "$buildDirAsFile/generated/sources/js/$fileName",
+	        "$dirName/$fileName"
 	    )
 	}
 	register<JavaExec>("compress-and-append-calendar-setup") {
 		val fileName = "calendar-setup.js"
-		val dirName = "${projectDir}/src/js/com/dynarch/calendar"
+		val dirName = "$projectDir/src/js/com/dynarch/calendar"
 		classpath = fileTree(
-			File("${projectDir}/etc/yuicompressor", "yuicompressor.jar")
+			File("$projectDir/etc/yuicompressor", "yuicompressor.jar")
 		)
 	    args = listOf(
 	        "--line-break", "1000",
-	        "-o", "$buildDir/generated/sources/js/${fileName}",
-	        "${dirName}/${fileName}"
+	        "-o", "$buildDirAsFile/generated/sources/js/$fileName",
+	        "$dirName/$fileName"
 	    )
 	}
 	register<JavaExec>("compress-and-append-guicontrol") {
 		val fileName = "guicontrol.js"
-		val dirName = "${projectDir}/src/js/org/openmdx/portal"
+		val dirName = "$projectDir/src/js/org/openmdx/portal"
 		classpath = fileTree(
-			File("${projectDir}/etc/yuicompressor", "yuicompressor.jar")
+			File("$projectDir/etc/yuicompressor", "yuicompressor.jar")
 		)
 	    args = listOf(
 	        "--line-break", "1000",
-	        "-o", "$buildDir/generated/sources/js/${fileName}",
-	        "${dirName}/${fileName}"
+	        "-o", "$buildDirAsFile/generated/sources/js/$fileName",
+	        "$dirName/$fileName"
 	    )
 	}
 	register<JavaExec>("compress-and-append-wiky") {
 		val fileName = "wiky.js"
-		val dirName = "${projectDir}/src/js/net/wiky"
+		val dirName = "$projectDir/src/js/net/wiky"
 		classpath = fileTree(
-			File("${projectDir}/etc/yuicompressor", "yuicompressor.jar")
+			File("$projectDir/etc/yuicompressor", "yuicompressor.jar")
 		)
 	    args = listOf(
 	        "--line-break", "1000",
-	        "-o", "$buildDir/generated/sources/js/${fileName}",
-	        "${dirName}/${fileName}"
+	        "-o", "$buildDirAsFile/generated/sources/js/$fileName",
+	        "$dirName/$fileName"
 	    )
 	}
 	register<JavaExec>("compress-and-append-wiky-lang") {
 		val fileName = "wiky.lang.js"
-		val dirName = "${projectDir}/src/js/net/wiky"
+		val dirName = "$projectDir/src/js/net/wiky"
 		classpath = fileTree(
-			File("${projectDir}/etc/yuicompressor", "yuicompressor.jar")
+			File("$projectDir/etc/yuicompressor", "yuicompressor.jar")
 		)
 	    args = listOf(
 	        "--line-break", "1000",
-	        "-o", "$buildDir/generated/sources/js/${fileName}",
-	        "${dirName}/${fileName}"
+	        "-o", "$buildDirAsFile/generated/sources/js/$fileName",
+	        "$dirName/$fileName"
 	    )
 	}
 	register<JavaExec>("compress-and-append-wiky-math") {
 		val fileName = "wiky.math.js"
-		val dirName = "${projectDir}/src/js/net/wiky"
+		val dirName = "$projectDir/src/js/net/wiky"
 		classpath = fileTree(
-			File("${projectDir}/etc/yuicompressor", "yuicompressor.jar")
+			File("$projectDir/etc/yuicompressor", "yuicompressor.jar")
 		)
 	    args = listOf(
 	        "--line-break", "1000",
-	        "-o", "$buildDir/generated/sources/js/${fileName}",
-	        "${dirName}/${fileName}"
+	        "-o", "$buildDirAsFile/generated/sources/js/$fileName",
+	        "$dirName/$fileName"
 	    )
 	}
 	register("compress-and-append-js") {
@@ -269,14 +272,14 @@ tasks {
 		dependsOn("compress-and-append-wiky-math")
 	    doLast {
 	    	val f = File(projectDir, "src/war/openmdx-inspector.war/js/portal-all.js")
-	        f.writeText(File("$buildDir/generated/sources/js/prototype.js").readText())
-	        f.appendText(File("$buildDir/generated/sources/js/ssf.js").readText())
-	        f.appendText(File("$buildDir/generated/sources/js/calendar.js").readText())
-	        f.appendText(File("$buildDir/generated/sources/js/calendar-setup.js").readText())
-	        f.appendText(File("$buildDir/generated/sources/js/guicontrol.js").readText())
-	        f.appendText(File("$buildDir/generated/sources/js/wiky.js").readText())
-	        f.appendText(File("$buildDir/generated/sources/js/wiky.lang.js").readText())
-	        f.appendText(File("$buildDir/generated/sources/js/wiky.math.js").readText())
+	        f.writeText(file(layout.buildDirectory.dir("generated/sources/js/prototype.js")).readText())
+	        f.appendText(file(layout.buildDirectory.dir("generated/sources/js/ssf.js")).readText())
+	        f.appendText(file(layout.buildDirectory.dir("generated/sources/js/calendar.js")).readText())
+	        f.appendText(file(layout.buildDirectory.dir("generated/sources/js/calendar-setup.js")).readText())
+	        f.appendText(file(layout.buildDirectory.dir("generated/sources/js/guicontrol.js")).readText())
+	        f.appendText(file(layout.buildDirectory.dir("generated/sources/js/wiky.js")).readText())
+	        f.appendText(file(layout.buildDirectory.dir("generated/sources/js/wiky.lang.js")).readText())
+	        f.appendText(file(layout.buildDirectory.dir("generated/sources/js/wiky.math.js")).readText())
 	    }
 	}
 	compileJava {
@@ -321,10 +324,10 @@ tasks {
 			)
 		}
 		from(
-			File(buildDir, "classes/java/main"),
-			File(buildDir, "resources/main"),
+			File(this.buildDirAsFile, "classes/java/main"),
+			File(this.buildDirAsFile, "resources/main"),
 			"src/main/resources",
-			zipTree(File(buildDir, "generated/sources/model/openmdx-${project.name}.openmdx-xmi.zip"))
+			zipTree(layout.buildDirectory.dir("generated/sources/model/openmdx-${project.name}.openmdx-xmi.zip"))
 		)
 		include(openmdxPortalIncludes)
 		exclude(openmdxPortalExcludes)
@@ -344,7 +347,7 @@ tasks {
 		}
 		from(
 			"src/main/java",
-			File(buildDir, "generated/sources/java/main")
+			File(this.buildDirAsFile, "generated/sources/java/main")
 		)
 		include(openmdxPortalIncludes)
 		exclude(openmdxPortalExcludes)

--- a/portal/build.gradle.kts
+++ b/portal/build.gradle.kts
@@ -61,7 +61,7 @@ repositories {
 }
 
 var env = Properties()
-env.load(FileInputStream(File(project.getRootDir(), "build.properties")))
+env.load(FileInputStream(File(project.rootDir, "build.properties")))
 val targetPlatform = JavaVersion.valueOf(env.getProperty("target.platform"))
 
 eclipse {
@@ -71,23 +71,23 @@ eclipse {
     jdt {
 		sourceCompatibility = targetPlatform
     	targetCompatibility = targetPlatform
-    	javaRuntimeName = "JavaSE-" + targetPlatform    	
+    	javaRuntimeName = "JavaSE-$targetPlatform"
     }
 }
 
 fun getProjectImplementationVersion(): String {
-	return project.getVersion().toString();
+	return project.version.toString();
 }
 
 fun getDeliverDir(): File {
-	return File(project.getRootDir(), "jre-" + targetPlatform + "/" + project.name);
+	return File(project.rootDir, "jre-" + targetPlatform + "/" + project.name);
 }
 
 fun touch(file: File) {
 	ant.withGroovyBuilder { "touch"("file" to file, "mkdirs" to true) }
 }
 
-project.getConfigurations().maybeCreate("openmdxBootstrap")
+project.configurations.maybeCreate("openmdxBootstrap")
 val openmdxBootstrap by configurations
 
 dependencies {
@@ -110,7 +110,7 @@ sourceSets {
         }
         resources {
         	srcDir("src/main/resources")
-        }        
+        }
     }
     test {
         java {
@@ -120,7 +120,7 @@ sourceSets {
         resources {
         	srcDir("src/test/resources")
         }
-    }    
+    }
 }
 
 touch(File(buildDir, "generated/sources/js/portal-all.js"))
@@ -145,15 +145,15 @@ tasks {
 	register<org.openmdx.gradle.GenerateModelsTask>("generate-model") {
 	    inputs.dir("${projectDir}/src/model/emf")
 	    inputs.dir("${projectDir}/src/main/resources")
-	    outputs.file("${buildDir}/generated/sources/model/openmdx-" + project.name + "-models.zip")
-	    outputs.file("${buildDir}/generated/sources/model/openmdx-" + project.name + ".openmdx-xmi.zip")
+	    outputs.file("${buildDir}/generated/sources/model/openmdx-${project.name}-models.zip")
+	    outputs.file("${buildDir}/generated/sources/model/openmdx-${project.name}.openmdx-xmi.zip")
 	    classpath = configurations["openmdxBootstrap"]
 	    doFirst {
 	    }
 	    doLast {
 	        copy {
 	            from(
-	                zipTree("${buildDir}/generated/sources/model/openmdx-" + project.name + "-models.zip")
+	                zipTree("${buildDir}/generated/sources/model/openmdx-${project.name}-models.zip")
 	            )
 	            into("$buildDir/generated/sources/java/main")
 	            include(
@@ -281,7 +281,7 @@ tasks {
 	}
 	compileJava {
 	    dependsOn("generate-model")
-	    options.release.set(Integer.valueOf(targetPlatform.getMajorVersion()))
+	    options.release.set(Integer.valueOf(targetPlatform.majorVersion))
 	}
 	assemble {
 		dependsOn(
@@ -324,7 +324,7 @@ tasks {
 			File(buildDir, "classes/java/main"),
 			File(buildDir, "resources/main"),
 			"src/main/resources",
-			zipTree(File(buildDir, "generated/sources/model/openmdx-" + project.name + ".openmdx-xmi.zip"))
+			zipTree(File(buildDir, "generated/sources/model/openmdx-${project.name}.openmdx-xmi.zip"))
 		)
 		include(openmdxPortalIncludes)
 		exclude(openmdxPortalExcludes)
@@ -420,7 +420,7 @@ tasks {
 
 distributions {
     main {
-    	distributionBaseName.set("openmdx-" + getProjectImplementationVersion() + "-" + project.name + "-jre-" + targetPlatform)
+    	distributionBaseName.set("openmdx-" + getProjectImplementationVersion() + "-${project.name}-jre-" + targetPlatform)
         contents {
         	// portal
         	from(".") { into(project.name); include("LICENSE", "*.LICENSE", "NOTICE", "*.properties", "build*.*", "*.xml", "*.kts") }
@@ -430,8 +430,10 @@ distributions {
             // rootDir
             from("..") { include("*.properties", "*.kts" ) }
             // jre-...
-            from("../jre-" + targetPlatform + "/" + project.name + "/lib") { into("jre-" + targetPlatform + "/" + project.name + "/lib") }
-            from("../jre-" + targetPlatform + "/gradle/repo") { into("jre-" + targetPlatform + "/gradle/repo") }
+			var path = "jre-$targetPlatform/${project.name}/lib"
+			from("../$path") { into(path) }
+			path = "jre-$targetPlatform/gradle/repo"
+			from("../$path") { into(path) }
         }
     }
 }

--- a/portal/build.gradle.kts
+++ b/portal/build.gradle.kts
@@ -43,10 +43,8 @@
  * listed in the NOTICE file.
  */
 
-import org.gradle.kotlin.dsl.*
-import org.w3c.dom.Element
+import java.io.FileInputStream
 import java.util.*
-import java.io.*
 
 plugins {
 	java
@@ -82,7 +80,7 @@ fun getProjectImplementationVersion(): String {
 }
 
 fun getDeliverDir(): File {
-	return File(project.getRootDir(), "jre-" + targetPlatform + "/" + project.getName());
+	return File(project.getRootDir(), "jre-" + targetPlatform + "/" + project.name);
 }
 
 fun touch(file: File) {
@@ -147,15 +145,15 @@ tasks {
 	register<org.openmdx.gradle.GenerateModelsTask>("generate-model") {
 	    inputs.dir("${projectDir}/src/model/emf")
 	    inputs.dir("${projectDir}/src/main/resources")
-	    outputs.file("${buildDir}/generated/sources/model/openmdx-" + project.getName() + "-models.zip")
-	    outputs.file("${buildDir}/generated/sources/model/openmdx-" + project.getName() + ".openmdx-xmi.zip")
+	    outputs.file("${buildDir}/generated/sources/model/openmdx-" + project.name + "-models.zip")
+	    outputs.file("${buildDir}/generated/sources/model/openmdx-" + project.name + ".openmdx-xmi.zip")
 	    classpath = configurations["openmdxBootstrap"]
 	    doFirst {
 	    }
 	    doLast {
 	        copy {
 	            from(
-	                zipTree("${buildDir}/generated/sources/model/openmdx-" + project.getName() + "-models.zip")
+	                zipTree("${buildDir}/generated/sources/model/openmdx-" + project.name + "-models.zip")
 	            )
 	            into("$buildDir/generated/sources/java/main")
 	            include(
@@ -326,7 +324,7 @@ tasks {
 			File(buildDir, "classes/java/main"),
 			File(buildDir, "resources/main"),
 			"src/main/resources",
-			zipTree(File(buildDir, "generated/sources/model/openmdx-" + project.getName() + ".openmdx-xmi.zip"))
+			zipTree(File(buildDir, "generated/sources/model/openmdx-" + project.name + ".openmdx-xmi.zip"))
 		)
 		include(openmdxPortalIncludes)
 		exclude(openmdxPortalExcludes)
@@ -422,17 +420,17 @@ tasks {
 
 distributions {
     main {
-    	distributionBaseName.set("openmdx-" + getProjectImplementationVersion() + "-" + project.getName() + "-jre-" + targetPlatform)
+    	distributionBaseName.set("openmdx-" + getProjectImplementationVersion() + "-" + project.name + "-jre-" + targetPlatform)
         contents {
         	// portal
-        	from(".") { into(project.getName()); include("LICENSE", "*.LICENSE", "NOTICE", "*.properties", "build*.*", "*.xml", "*.kts") }
-            from("src") { into(project.getName() + "/src") }
+        	from(".") { into(project.name); include("LICENSE", "*.LICENSE", "NOTICE", "*.properties", "build*.*", "*.xml", "*.kts") }
+            from("src") { into(project.name + "/src") }
             // etc
-            from("etc") { into(project.getName() + "/etc") }
+            from("etc") { into(project.name + "/etc") }
             // rootDir
             from("..") { include("*.properties", "*.kts" ) }
             // jre-...
-            from("../jre-" + targetPlatform + "/" + project.getName() + "/lib") { into("jre-" + targetPlatform + "/" + project.getName() + "/lib") }
+            from("../jre-" + targetPlatform + "/" + project.name + "/lib") { into("jre-" + targetPlatform + "/" + project.name + "/lib") }
             from("../jre-" + targetPlatform + "/gradle/repo") { into("jre-" + targetPlatform + "/gradle/repo") }
         }
     }

--- a/portal/build.gradle.kts
+++ b/portal/build.gradle.kts
@@ -302,10 +302,10 @@ tasks {
 
 	val openmdxPortalExcludes = listOf<String>( )
 
-	named("processResources", Copy::class.java) { duplicatesStrategy = DuplicatesStrategy.WARN }
-	named("processTestResources", Copy::class.java) { duplicatesStrategy = DuplicatesStrategy.WARN }
+	named("processResources", Copy::class.java) { duplicatesStrategy = DuplicatesStrategy.EXCLUDE }
+	named("processTestResources", Copy::class.java) { duplicatesStrategy = DuplicatesStrategy.EXCLUDE }
 	register<org.openmdx.gradle.ArchiveTask>("openmdx-portal.jar") {
-		duplicatesStrategy = DuplicatesStrategy.WARN
+		duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 		dependsOn(
 			":portal:compileJava",
 			":portal:generate-model",
@@ -332,7 +332,7 @@ tasks {
 		exclude(openmdxPortalExcludes)
 	}
 	register<org.openmdx.gradle.ArchiveTask>("openmdx-portal-sources.jar") {
-		duplicatesStrategy = DuplicatesStrategy.WARN
+		duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 		destinationDirectory.set(File(getDeliverDir(), "lib"))
 		archiveFileName.set("openmdx-portal-sources.jar")
 		includeEmptyDirs = false

--- a/publish/build.gradle.kts
+++ b/publish/build.gradle.kts
@@ -67,8 +67,8 @@ publishing {
         maven {
         	// Publish to local
         	/**/
-            val releasesRepoUrl = uri("${buildDir}/repos/releases")
-            val snapshotsRepoUrl = uri("${buildDir}/repos/snapshots")
+            val releasesRepoUrl = uri(layout.buildDirectory.dir("repos/releases"))
+            val snapshotsRepoUrl = uri(layout.buildDirectory.dir("repos/snapshots"))
             /**/
             // Publish to OSSRH
             /*
@@ -88,7 +88,7 @@ publishing {
             artifactId = "openmdx-system"
             artifact(project.artifacts.add("archives", File("${rootDir}/jre-" + targetPlatform + "/core/lib/openmdx-system.jar")) { type = "jar" })
             artifact(project.artifacts.add("archives", File("${rootDir}/jre-" + targetPlatform + "/core/lib/openmdx-system-sources.jar")) { type = "jar"; classifier = "sources" })
-            artifact(project.artifacts.add("archives", File("${projectDir}/src/main/maven/openmdx-system-javadoc.jar")) { type = "jar"; classifier = "javadoc" })
+            artifact(project.artifacts.add("archives", File("$projectDir/src/main/maven/openmdx-system-javadoc.jar")) { type = "jar"; classifier = "javadoc" })
             pom {
                 name.set("openmdx-system")
                 description.set("openMDX/System Library")
@@ -122,7 +122,7 @@ publishing {
             artifactId = "openmdx-base"
             artifact(project.artifacts.add("archives", File("${rootDir}/jre-" + targetPlatform + "/core/lib/openmdx-base.jar")) { type = "jar" })
             artifact(project.artifacts.add("archives", File("${rootDir}/jre-" + targetPlatform + "/core/lib/openmdx-base-sources.jar")) { type = "jar"; classifier = "sources" })
-            artifact(project.artifacts.add("archives", File("${projectDir}/src/main/maven/openmdx-base-javadoc.jar")) { type = "jar"; classifier = "javadoc" })
+            artifact(project.artifacts.add("archives", File("$projectDir/src/main/maven/openmdx-base-javadoc.jar")) { type = "jar"; classifier = "javadoc" })
             pom {
                 name.set("openmdx-base")
                 description.set("openMDX/Base Library")
@@ -155,8 +155,8 @@ publishing {
         create<MavenPublication>("openmdxBaseModels") {
             artifactId = "openmdx-base-models"
             artifact(project.artifacts.add("archives", File("${rootDir}/core/build/generated/sources/model/openmdx-core.openmdx-emf.zip")) { type = "jar" })
-            artifact(project.artifacts.add("archives", File("${projectDir}/src/main/maven/openmdx-base-models-sources.jar")) { type = "jar"; classifier = "sources" })
-            artifact(project.artifacts.add("archives", File("${projectDir}/src/main/maven/openmdx-base-models-javadoc.jar")) { type = "jar"; classifier = "javadoc" })
+            artifact(project.artifacts.add("archives", File("$projectDir/src/main/maven/openmdx-base-models-sources.jar")) { type = "jar"; classifier = "sources" })
+            artifact(project.artifacts.add("archives", File("$projectDir/src/main/maven/openmdx-base-models-javadoc.jar")) { type = "jar"; classifier = "javadoc" })
             pom {
                 name.set("openmdx-base-models")
                 description.set("openMDX/Base Models Library")
@@ -190,7 +190,7 @@ publishing {
             artifactId = "openmdx-client"
             artifact(project.artifacts.add("archives", File("${rootDir}/jre-" + targetPlatform + "/client/lib/openmdx-client.jar")) { type = "jar" })
             artifact(project.artifacts.add("archives", File("${rootDir}/jre-" + targetPlatform + "/client/lib/openmdx-client-sources.jar")) { type = "jar"; classifier = "sources" })
-            artifact(project.artifacts.add("archives", File("${projectDir}/src/main/maven/openmdx-client-javadoc.jar")) { type = "jar"; classifier = "javadoc" })
+            artifact(project.artifacts.add("archives", File("$projectDir/src/main/maven/openmdx-client-javadoc.jar")) { type = "jar"; classifier = "javadoc" })
             pom {
                 name.set("openmdx-client")
                 description.set("openMDX/Client Library")
@@ -224,7 +224,7 @@ publishing {
             artifactId = "openmdx-dalvik"
             artifact(project.artifacts.add("archives", File("${rootDir}/jre-" + targetPlatform + "/client/lib/openmdx-dalvik.jar")) { type = "jar" })
             artifact(project.artifacts.add("archives", File("${rootDir}/jre-" + targetPlatform + "/client/lib/openmdx-dalvik-sources.jar")) { type = "jar"; classifier = "sources" })
-            artifact(project.artifacts.add("archives", File("${projectDir}/src/main/maven/openmdx-dalvik-javadoc.jar")) { type = "jar"; classifier = "javadoc" })
+            artifact(project.artifacts.add("archives", File("$projectDir/src/main/maven/openmdx-dalvik-javadoc.jar")) { type = "jar"; classifier = "javadoc" })
             pom {
                 name.set("openmdx-dalvik")
                 description.set("openMDX/Dalvik Library")
@@ -258,7 +258,7 @@ publishing {
             artifactId = "openmdx-security"
             artifact(project.artifacts.add("archives", File("${rootDir}/jre-" + targetPlatform + "/security/lib/openmdx-security.jar")) { type = "jar" })
             artifact(project.artifacts.add("archives", File("${rootDir}/jre-" + targetPlatform + "/security/lib/openmdx-security-sources.jar")) { type = "jar"; classifier = "sources" })
-            artifact(project.artifacts.add("archives", File("${projectDir}/src/main/maven/openmdx-security-javadoc.jar")) { type = "jar"; classifier = "javadoc" })
+            artifact(project.artifacts.add("archives", File("$projectDir/src/main/maven/openmdx-security-javadoc.jar")) { type = "jar"; classifier = "javadoc" })
             pom {
                 name.set("openmdx-security")
                 description.set("openMDX/Security Library")
@@ -291,8 +291,8 @@ publishing {
         create<MavenPublication>("openmdxSecurityModels") {
             artifactId = "openmdx-security-models"
             artifact(project.artifacts.add("archives", File("${rootDir}/security/build/generated/sources/model/openmdx-security.openmdx-emf.zip")) { type = "jar" })
-            artifact(project.artifacts.add("archives", File("${projectDir}/src/main/maven/openmdx-security-models-sources.jar")) { type = "jar"; classifier = "sources" })
-            artifact(project.artifacts.add("archives", File("${projectDir}/src/main/maven/openmdx-security-models-javadoc.jar")) { type = "jar"; classifier = "javadoc" })
+            artifact(project.artifacts.add("archives", File("$projectDir/src/main/maven/openmdx-security-models-sources.jar")) { type = "jar"; classifier = "sources" })
+            artifact(project.artifacts.add("archives", File("$projectDir/src/main/maven/openmdx-security-models-javadoc.jar")) { type = "jar"; classifier = "javadoc" })
             pom {
                 name.set("openmdx-security-models")
                 description.set("openMDX/Security Models Library")
@@ -326,7 +326,7 @@ publishing {
             artifactId = "openmdx-authentication"
             artifact(project.artifacts.add("archives", File("${rootDir}/jre-" + targetPlatform + "/security/lib/openmdx-authentication.jar")) { type = "jar" })
             artifact(project.artifacts.add("archives", File("${rootDir}/jre-" + targetPlatform + "/security/lib/openmdx-authentication-sources.jar")) { type = "jar"; classifier = "sources" })
-            artifact(project.artifacts.add("archives", File("${projectDir}/src/main/maven/openmdx-authentication-javadoc.jar")) { type = "jar"; classifier = "javadoc" })
+            artifact(project.artifacts.add("archives", File("$projectDir/src/main/maven/openmdx-authentication-javadoc.jar")) { type = "jar"; classifier = "javadoc" })
             pom {
                 name.set("openmdx-authentication")
                 description.set("openMDX/Authentication Library")
@@ -360,7 +360,7 @@ publishing {
             artifactId = "openmdx-ldap"
             artifact(project.artifacts.add("archives", File("${rootDir}/jre-" + targetPlatform + "/security/lib/openmdx-ldap.jar")) { type = "jar" })
             artifact(project.artifacts.add("archives", File("${rootDir}/jre-" + targetPlatform + "/security/lib/openmdx-ldap-sources.jar")) { type = "jar"; classifier = "sources" })
-            artifact(project.artifacts.add("archives", File("${projectDir}/src/main/maven/openmdx-ldap-javadoc.jar")) { type = "jar"; classifier = "javadoc" })
+            artifact(project.artifacts.add("archives", File("$projectDir/src/main/maven/openmdx-ldap-javadoc.jar")) { type = "jar"; classifier = "javadoc" })
             pom {
                 name.set("openmdx-ldap")
                 description.set("openMDX/Ldap Library")
@@ -394,7 +394,7 @@ publishing {
             artifactId = "openmdx-pki"
             artifact(project.artifacts.add("archives", File("${rootDir}/jre-" + targetPlatform + "/security/lib/openmdx-pki.jar")) { type = "jar" })
             artifact(project.artifacts.add("archives", File("${rootDir}/jre-" + targetPlatform + "/security/lib/openmdx-pki-sources.jar")) { type = "jar"; classifier = "sources" })
-            artifact(project.artifacts.add("archives", File("${projectDir}/src/main/maven/openmdx-pki-javadoc.jar")) { type = "jar"; classifier = "javadoc" })
+            artifact(project.artifacts.add("archives", File("$projectDir/src/main/maven/openmdx-pki-javadoc.jar")) { type = "jar"; classifier = "javadoc" })
             pom {
                 name.set("openmdx-pki")
                 description.set("openMDX/Pki Library")
@@ -428,7 +428,7 @@ publishing {
             artifactId = "openmdx-radius"
             artifact(project.artifacts.add("archives", File("${rootDir}/jre-" + targetPlatform + "/security/lib/openmdx-radius.jar")) { type = "jar" })
             artifact(project.artifacts.add("archives", File("${rootDir}/jre-" + targetPlatform + "/security/lib/openmdx-radius-sources.jar")) { type = "jar"; classifier = "sources" })
-            artifact(project.artifacts.add("archives", File("${projectDir}/src/main/maven/openmdx-radius-javadoc.jar")) { type = "jar"; classifier = "javadoc" })
+            artifact(project.artifacts.add("archives", File("$projectDir/src/main/maven/openmdx-radius-javadoc.jar")) { type = "jar"; classifier = "javadoc" })
             pom {
                 name.set("openmdx-radius")
                 description.set("openMDX/Radius Library")
@@ -462,7 +462,7 @@ publishing {
             artifactId = "openmdx-resource"
             artifact(project.artifacts.add("archives", File("${rootDir}/jre-" + targetPlatform + "/security/lib/openmdx-resource.jar")) { type = "jar" })
             artifact(project.artifacts.add("archives", File("${rootDir}/jre-" + targetPlatform + "/security/lib/openmdx-resource-sources.jar")) { type = "jar"; classifier = "sources" })
-            artifact(project.artifacts.add("archives", File("${projectDir}/src/main/maven/openmdx-resource-javadoc.jar")) { type = "jar"; classifier = "javadoc" })
+            artifact(project.artifacts.add("archives", File("$projectDir/src/main/maven/openmdx-resource-javadoc.jar")) { type = "jar"; classifier = "javadoc" })
             pom {
                 name.set("openmdx-resource")
                 description.set("openMDX/Resource Library")
@@ -496,7 +496,7 @@ publishing {
             artifactId = "openmdx-portal"
             artifact(project.artifacts.add("archives", File("${rootDir}/jre-" + targetPlatform + "/portal/lib/openmdx-portal.jar")) { type = "jar" })
             artifact(project.artifacts.add("archives", File("${rootDir}/jre-" + targetPlatform + "/portal/lib/openmdx-portal-sources.jar")) { type = "jar"; classifier = "sources" })
-            artifact(project.artifacts.add("archives", File("${projectDir}/src/main/maven/openmdx-portal-javadoc.jar")) { type = "jar"; classifier = "javadoc" })
+            artifact(project.artifacts.add("archives", File("$projectDir/src/main/maven/openmdx-portal-javadoc.jar")) { type = "jar"; classifier = "javadoc" })
             pom {
                 name.set("openmdx-portal")
                 description.set("openMDX/Portal Library")
@@ -529,8 +529,8 @@ publishing {
         create<MavenPublication>("openmdxPortalModels") {
             artifactId = "openmdx-portal-models"
             artifact(project.artifacts.add("archives", File("${rootDir}/portal/build/generated/sources/model/openmdx-portal.openmdx-emf.zip")) { type = "jar" })
-            artifact(project.artifacts.add("archives", File("${projectDir}/src/main/maven/openmdx-portal-models-sources.jar")) { type = "jar"; classifier = "sources" })
-            artifact(project.artifacts.add("archives", File("${projectDir}/src/main/maven/openmdx-portal-models-javadoc.jar")) { type = "jar"; classifier = "javadoc" })
+            artifact(project.artifacts.add("archives", File("$projectDir/src/main/maven/openmdx-portal-models-sources.jar")) { type = "jar"; classifier = "sources" })
+            artifact(project.artifacts.add("archives", File("$projectDir/src/main/maven/openmdx-portal-models-javadoc.jar")) { type = "jar"; classifier = "javadoc" })
             pom {
                 name.set("openmdx-portal-models")
                 description.set("openMDX/Portal Models Library")
@@ -563,8 +563,8 @@ publishing {
         create<MavenPublication>("openmdxInspector") {
             artifactId = "openmdx-inspector"
             artifact(project.artifacts.add("archives", File("${rootDir}/jre-" + targetPlatform + "/portal/deployment-unit/openmdx-inspector.war")) { type = "war" })
-            artifact(project.artifacts.add("archives", File("${projectDir}/src/main/maven/openmdx-inspector-sources.jar")) { type = "jar"; classifier = "sources" })
-            artifact(project.artifacts.add("archives", File("${projectDir}/src/main/maven/openmdx-inspector-javadoc.jar")) { type = "jar"; classifier = "javadoc" })
+            artifact(project.artifacts.add("archives", File("$projectDir/src/main/maven/openmdx-inspector-sources.jar")) { type = "jar"; classifier = "sources" })
+            artifact(project.artifacts.add("archives", File("$projectDir/src/main/maven/openmdx-inspector-javadoc.jar")) { type = "jar"; classifier = "javadoc" })
             pom {
                 name.set("openmdx-inspector")
                 description.set("openMDX/Inspector Library")
@@ -598,7 +598,7 @@ publishing {
             artifactId = "catalina-openmdx"
             artifact(project.artifacts.add("archives", File("${rootDir}/jre-" + targetPlatform + "/tomcat/lib/catalina-openmdx.jar")) { type = "war" })
             artifact(project.artifacts.add("archives", File("${rootDir}/jre-" + targetPlatform + "/tomcat/lib/catalina-openmdx-sources.jar")) { type = "jar"; classifier = "sources" })
-            artifact(project.artifacts.add("archives", File("${projectDir}/src/main/maven/catalina-openmdx-javadoc.jar")) { type = "jar"; classifier = "javadoc" })
+            artifact(project.artifacts.add("archives", File("$projectDir/src/main/maven/catalina-openmdx-javadoc.jar")) { type = "jar"; classifier = "javadoc" })
             pom {
                 name.set("catalina-openmdx")
                 description.set("openMDX/Catalina Library")

--- a/security/build.gradle.kts
+++ b/security/build.gradle.kts
@@ -202,8 +202,8 @@ tasks {
         )
 	}
 
-	named("processResources", Copy::class.java) { duplicatesStrategy = DuplicatesStrategy.WARN }
-	named("processTestResources", Copy::class.java) { duplicatesStrategy = DuplicatesStrategy.WARN }
+	named("processResources", Copy::class.java) { duplicatesStrategy = DuplicatesStrategy.EXCLUDE }
+	named("processTestResources", Copy::class.java) { duplicatesStrategy = DuplicatesStrategy.EXCLUDE }
 
 	val openmdxSecurityIncludes = listOf(
 		"org/openmdx/security/*/**",
@@ -219,7 +219,7 @@ tasks {
 	)
 
 	register<org.openmdx.gradle.ArchiveTask>("openmdx-security.jar") {
-		duplicatesStrategy = DuplicatesStrategy.WARN
+		duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 		dependsOn(
 			":security:compileJava",
 			":security:generate-model",
@@ -247,7 +247,7 @@ tasks {
 	}
 
 	register<org.openmdx.gradle.ArchiveTask>("openmdx-security-sources.jar") {
-		duplicatesStrategy = DuplicatesStrategy.WARN
+		duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 		destinationDirectory.set(File(getDeliverDir(), "lib"))
 		archiveFileName.set("openmdx-security-sources.jar")
 		includeEmptyDirs = false
@@ -275,7 +275,7 @@ tasks {
 	val openmdxAuthenticationExcludes = listOf<String>( )
 
 	register<org.openmdx.gradle.ArchiveTask>("openmdx-authentication.jar") {
-		duplicatesStrategy = DuplicatesStrategy.WARN
+		duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 		dependsOn(
 			":security:compileJava",
 			":security:processResources"

--- a/security/build.gradle.kts
+++ b/security/build.gradle.kts
@@ -80,7 +80,7 @@ fun getProjectImplementationVersion(): String {
 }
 
 fun getDeliverDir(): File {
-	return File(project.getRootDir(), "jre-" + targetPlatform + "/" + project.getName());
+	return File(project.getRootDir(), "jre-" + targetPlatform + "/" + project.name);
 }
 
 fun touch(file: File) {
@@ -164,15 +164,15 @@ tasks {
 	register<org.openmdx.gradle.GenerateModelsTask>("generate-model") {
 	    inputs.dir("${projectDir}/src/model/emf")
 	    inputs.dir("${projectDir}/src/main/resources")
-	    outputs.file("${buildDir}/generated/sources/model/openmdx-" + project.getName() + "-models.zip")
-	    outputs.file("${buildDir}/generated/sources/model/openmdx-" + project.getName() + ".openmdx-xmi.zip")
+	    outputs.file("${buildDir}/generated/sources/model/openmdx-" + project.name + "-models.zip")
+	    outputs.file("${buildDir}/generated/sources/model/openmdx-" + project.name + ".openmdx-xmi.zip")
 	    classpath = configurations["openmdxBootstrap"]
 	    doFirst {
 	    }
 	    doLast {
 	        copy {
 	            from(
-	                zipTree("${buildDir}/generated/sources/model/openmdx-" + project.getName() + "-models.zip")
+	                zipTree("${buildDir}/generated/sources/model/openmdx-" + project.name + "-models.zip")
 	            )
 	            into("$buildDir/generated/sources/java/main")
 	            include(
@@ -240,7 +240,7 @@ tasks {
 			File(buildDir, "classes/java/main"),
 			File(buildDir, "resources/main"),
 			"src/main/resources",
-			zipTree(File(buildDir, "generated/sources/model/openmdx-" + project.getName() + ".openmdx-xmi.zip"))
+			zipTree(File(buildDir, "generated/sources/model/openmdx-" + project.name + ".openmdx-xmi.zip"))
 		)
 		include(openmdxSecurityIncludes)
 		exclude(openmdxSecurityExcludes)
@@ -533,17 +533,17 @@ tasks {
 
 distributions {
     main {
-    	distributionBaseName.set("openmdx-" + getProjectImplementationVersion() + "-" + project.getName() + "-jre-" + targetPlatform)
+    	distributionBaseName.set("openmdx-" + getProjectImplementationVersion() + "-" + project.name + "-jre-" + targetPlatform)
         contents {
         	// security
-        	from(".") { into(project.getName()); include("LICENSE", "*.LICENSE", "NOTICE", "*.properties", "build*.*", "*.xml", "*.kts") }
-            from("src") { into(project.getName() + "/src") }
+        	from(".") { into(project.name); include("LICENSE", "*.LICENSE", "NOTICE", "*.properties", "build*.*", "*.xml", "*.kts") }
+            from("src") { into(project.name + "/src") }
             // etc
-            from("etc") { into(project.getName() + "/etc") }
+            from("etc") { into(project.name + "/etc") }
             // rootDir
             from("..") { include("*.properties", "*.kts" ) }
             // jre-...
-            from("../jre-" + targetPlatform + "/" + project.getName() + "/lib") { into("jre-" + targetPlatform + "/" + project.getName() + "/lib") }
+            from("../jre-" + targetPlatform + "/" + project.name + "/lib") { into("jre-" + targetPlatform + "/" + project.name + "/lib") }
             from("../jre-" + targetPlatform + "/gradle/repo") { into("jre-" + targetPlatform + "/gradle/repo") }
         }
     }

--- a/security/build.gradle.kts
+++ b/security/build.gradle.kts
@@ -61,7 +61,7 @@ repositories {
 }
 
 var env = Properties()
-env.load(FileInputStream(File(project.getRootDir(), "build.properties")))
+env.load(FileInputStream(File(project.rootDir, "build.properties")))
 val targetPlatform = JavaVersion.valueOf(env.getProperty("target.platform"))
 
 eclipse {
@@ -71,23 +71,23 @@ eclipse {
     jdt {
 		sourceCompatibility = targetPlatform
     	targetCompatibility = targetPlatform
-    	javaRuntimeName = "JavaSE-" + targetPlatform    	
+    	javaRuntimeName = "JavaSE-$targetPlatform"
     }
 }
 
 fun getProjectImplementationVersion(): String {
-	return project.getVersion().toString();
+	return project.version.toString();
 }
 
 fun getDeliverDir(): File {
-	return File(project.getRootDir(), "jre-" + targetPlatform + "/" + project.name);
+	return File(project.rootDir, "jre-" + targetPlatform + "/" + project.name);
 }
 
 fun touch(file: File) {
 	ant.withGroovyBuilder { "touch"("file" to file, "mkdirs" to true) }
 }
 
-project.getConfigurations().maybeCreate("openmdxBootstrap")
+project.configurations.maybeCreate("openmdxBootstrap")
 val openmdxBootstrap by configurations
 
 dependencies {
@@ -96,7 +96,7 @@ dependencies {
     implementation("javax:javaee-api:8.0.+")
     implementation("javax.jdo:jdo-api:3.1")    
     implementation("org.apache.directory.api:apache-ldap-api:2.0.+")    
-    // Test
+    // Test
     testImplementation("org.junit.jupiter:junit-jupiter-engine:5.8.2")
     testImplementation("org.mockito:mockito-core:4.2.0")    
     testImplementation("org.mockito:mockito-junit-jupiter:4.2.0")    
@@ -112,7 +112,7 @@ sourceSets {
         }
         resources {
         	srcDir("src/main/resources")
-        }        
+        }
     }
     test {
         java {
@@ -120,7 +120,7 @@ sourceSets {
         }
         resources {
         	srcDir("src/test/resources")
-        }        
+        }
     }
 }
 
@@ -164,15 +164,15 @@ tasks {
 	register<org.openmdx.gradle.GenerateModelsTask>("generate-model") {
 	    inputs.dir("${projectDir}/src/model/emf")
 	    inputs.dir("${projectDir}/src/main/resources")
-	    outputs.file("${buildDir}/generated/sources/model/openmdx-" + project.name + "-models.zip")
-	    outputs.file("${buildDir}/generated/sources/model/openmdx-" + project.name + ".openmdx-xmi.zip")
+	    outputs.file("${buildDir}/generated/sources/model/openmdx-${project.name}-models.zip")
+	    outputs.file("${buildDir}/generated/sources/model/openmdx-${project.name}.openmdx-xmi.zip")
 	    classpath = configurations["openmdxBootstrap"]
 	    doFirst {
 	    }
 	    doLast {
 	        copy {
 	            from(
-	                zipTree("${buildDir}/generated/sources/model/openmdx-" + project.name + "-models.zip")
+	                zipTree("${buildDir}/generated/sources/model/openmdx-${project.name}-models.zip")
 	            )
 	            into("$buildDir/generated/sources/java/main")
 	            include(
@@ -183,7 +183,7 @@ tasks {
 	}
 	compileJava {
 	    dependsOn("generate-model")
-	    options.release.set(Integer.valueOf(targetPlatform.getMajorVersion()))
+	    options.release.set(Integer.valueOf(targetPlatform.majorVersion))
 	}
 	assemble {
 		dependsOn(
@@ -543,8 +543,10 @@ distributions {
             // rootDir
             from("..") { include("*.properties", "*.kts" ) }
             // jre-...
-            from("../jre-" + targetPlatform + "/" + project.name + "/lib") { into("jre-" + targetPlatform + "/" + project.name + "/lib") }
-            from("../jre-" + targetPlatform + "/gradle/repo") { into("jre-" + targetPlatform + "/gradle/repo") }
+			var path = "jre-$targetPlatform/${project.name}/lib"
+			from("../$path") { into(path) }
+			path = "jre-$targetPlatform/gradle/repo"
+			from("../$path") { into(path) }
         }
     }
 }

--- a/security/build.gradle.kts
+++ b/security/build.gradle.kts
@@ -108,7 +108,7 @@ sourceSets {
     main {
         java {
             srcDir("src/main/java")
-            srcDir("$buildDir/generated/sources/java/main")
+            srcDir(layout.buildDirectory.dir("generated/sources/java/main"))
         }
         resources {
         	srcDir("src/main/resources")
@@ -162,19 +162,19 @@ tasks {
 		)
 	}
 	register<org.openmdx.gradle.GenerateModelsTask>("generate-model") {
-	    inputs.dir("${projectDir}/src/model/emf")
-	    inputs.dir("${projectDir}/src/main/resources")
-	    outputs.file("${buildDir}/generated/sources/model/openmdx-${project.name}-models.zip")
-	    outputs.file("${buildDir}/generated/sources/model/openmdx-${project.name}.openmdx-xmi.zip")
+	    inputs.dir("$projectDir/src/model/emf")
+	    inputs.dir("$projectDir/src/main/resources")
+	    outputs.file(layout.buildDirectory.dir("generated/sources/model/openmdx-${project.name}-models.zip"))
+	    outputs.file(layout.buildDirectory.dir("generated/sources/model/openmdx-${project.name}.openmdx-xmi.zip"))
 	    classpath = configurations["openmdxBootstrap"]
 	    doFirst {
 	    }
 	    doLast {
 	        copy {
 	            from(
-	                zipTree("${buildDir}/generated/sources/model/openmdx-${project.name}-models.zip")
+	                zipTree(layout.buildDirectory.dir("generated/sources/model/openmdx-${project.name}-models.zip"))
 	            )
-	            into("$buildDir/generated/sources/java/main")
+	            into(layout.buildDirectory.dir("generated/sources/java/main"))
 	            include(
 	                "**/*.java"
 	            )
@@ -237,10 +237,10 @@ tasks {
 			)
 		}
 		from(
-			File(buildDir, "classes/java/main"),
-			File(buildDir, "resources/main"),
+			File(buildDirAsFile, "classes/java/main"),
+			File(buildDirAsFile, "resources/main"),
 			"src/main/resources",
-			zipTree(File(buildDir, "generated/sources/model/openmdx-" + project.name + ".openmdx-xmi.zip"))
+			zipTree(layout.buildDirectory.dir("generated/sources/model/openmdx-" + project.name + ".openmdx-xmi.zip"))
 		)
 		include(openmdxSecurityIncludes)
 		exclude(openmdxSecurityExcludes)
@@ -261,7 +261,7 @@ tasks {
 		}
 		from(
 			"src/main/java",
-			File(buildDir, "generated/sources/java/main")
+			File(buildDirAsFile, "generated/sources/java/main")
 		)
 		include(openmdxSecurityIncludes)
 		exclude(openmdxSecurityExcludes)
@@ -292,8 +292,8 @@ tasks {
 			)
 		}
 		from(
-			File(buildDir, "classes/java/main"),
-			File(buildDir, "resources/main"),
+			File(buildDirAsFile, "classes/java/main"),
+			File(buildDirAsFile, "resources/main"),
 			"src/main/resources"
 		)
 		include(openmdxAuthenticationIncludes)
@@ -314,7 +314,7 @@ tasks {
 		}
 		from(
 			"src/main/java",
-			File(buildDir, "generated/sources/java/main")
+			File(buildDirAsFile, "generated/sources/java/main")
 		)
 		include(openmdxAuthenticationIncludes)
 		exclude(openmdxAuthenticationExcludes)
@@ -350,8 +350,8 @@ tasks {
 			)
 		}
 		from(
-			File(buildDir, "classes/java/main"),
-			File(buildDir, "resources/main"),
+			File(buildDirAsFile, "classes/java/main"),
+			File(buildDirAsFile, "resources/main"),
 			"src/main/resources",
 			zipTree(File(getDeliverDir(), "../core/lib/openmdx-base.jar"))
 		)
@@ -373,7 +373,7 @@ tasks {
 		}
 		from(
 			"src/main/java",
-			File(buildDir, "generated/sources/java/main")
+			File(buildDirAsFile, "generated/sources/java/main")
 		)
 		include(openmdxRadiusIncludes)
 		exclude(openmdxRadiusExcludes)
@@ -401,8 +401,8 @@ tasks {
 			)
 		}
 		from(
-			File(buildDir, "classes/java/main"),
-			File(buildDir, "resources/main"),
+			File(buildDirAsFile, "classes/java/main"),
+			File(buildDirAsFile, "resources/main"),
 			"src/main/resources"
 		)
 		include(openmdxLdapIncludes)
@@ -423,7 +423,7 @@ tasks {
 		}
 		from(
 			"src/main/java",
-			File(buildDir, "generated/sources/java/main")
+			File(buildDirAsFile, "generated/sources/java/main")
 		)
 		include(openmdxLdapIncludes)
 		exclude(openmdxLdapExcludes)
@@ -452,8 +452,8 @@ tasks {
 			)
 		}
 		from(
-			File(buildDir, "classes/java/main"),
-			File(buildDir, "resources/main"),
+			File(buildDirAsFile, "classes/java/main"),
+			File(buildDirAsFile, "resources/main"),
 			"src/main/resources"
 		)
 		include(openmdxPkiIncludes)
@@ -474,7 +474,7 @@ tasks {
 		}
 		from(
 			"src/main/java",
-			File(buildDir, "generated/sources/java/main")
+			File(buildDirAsFile, "generated/sources/java/main")
 		)
 		include(openmdxPkiIncludes)
 		exclude(openmdxPkiExcludes)
@@ -503,8 +503,8 @@ tasks {
 			)
 		}
 		from(
-			File(buildDir, "classes/java/main"),
-			File(buildDir, "resources/main"),
+			File(buildDirAsFile, "classes/java/main"),
+			File(buildDirAsFile, "resources/main"),
 			"src/main/resources"
 		)
 		include(openmdxResourceIncludes)
@@ -524,7 +524,7 @@ tasks {
 		}
 		from(
 			"src/main/java",
-			File(buildDir, "generated/sources/java/main")
+			File(buildDirAsFile, "generated/sources/java/main")
 		)
 		include(openmdxResourceIncludes)
 		exclude(openmdxResourceExcludes)

--- a/security/src/main/java/org/openmdx/resource/ldap/ldif/Repository.java
+++ b/security/src/main/java/org/openmdx/resource/ldap/ldif/Repository.java
@@ -92,7 +92,7 @@ import org.apache.directory.ldap.client.api.LdapConnection;
 import org.apache.directory.ldap.client.api.SaslRequest;
 
 /**
- * LDAP repository
+ * LDAP repository
  */
 class Repository implements LdapConnection {
 
@@ -111,7 +111,7 @@ class Repository implements LdapConnection {
 	            entries.add(entry);
 	        }
         } catch (LdapException | IOException e) {
-            throw new CommException("Unable to populate the LDAP repository from " + source, e);
+            throw new CommException("Unable to populate the LDAP repository from " + source, e);
         }
 	}
 

--- a/test-core/build.gradle.kts
+++ b/test-core/build.gradle.kts
@@ -152,10 +152,10 @@ tasks.test {
 }
 
 project.tasks.named("processResources", Copy::class.java) {
-    duplicatesStrategy = DuplicatesStrategy.WARN
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 }
 project.tasks.named("processTestResources", Copy::class.java) {
-    duplicatesStrategy = DuplicatesStrategy.WARN
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 }
 
 tasks.register<org.openmdx.gradle.GenerateModelsTask>("generate-model") {

--- a/test-core/build.gradle.kts
+++ b/test-core/build.gradle.kts
@@ -114,17 +114,17 @@ sourceSets {
     main {
         java {
             srcDir("src/main/java")
-            srcDir("${buildDir}/generated/sources/java/main")
+            srcDir(layout.buildDirectory.dir("generated/sources/java/main"))
         }
         resources {
         	srcDir("src/main/resources")
-            srcDir("$buildDir/generated/resources/main")
+            srcDir(layout.buildDirectory.dir("generated/resources/main"))
         }
     }
     test {
         java {
             srcDir("src/test/java")
-            srcDir("${buildDir}/generated/sources/java/test")
+            srcDir(layout.buildDirectory.dir("generated/sources/java/test"))
         }
         resources {
         	srcDir("src/test/resources")
@@ -158,10 +158,10 @@ project.tasks.named("processTestResources", Copy::class.java) {
 
 tasks.register<org.openmdx.gradle.GenerateModelsTask>("generate-model") {
 	dependsOn("openmdxDatatypeClasses")
-    inputs.dir("${projectDir}/src/model/emf")
-    inputs.dir("${projectDir}/src/main/resources")
-    outputs.file("${buildDir}/generated/sources/model/openmdx-${project.name}-models.zip")
-    outputs.file("${buildDir}/generated/sources/model/openmdx-${project.name}.openmdx-xmi.zip")
+    inputs.dir("$projectDir/src/model/emf")
+    inputs.dir("$projectDir/src/main/resources")
+    outputs.file(layout.buildDirectory.dir("generated/sources/model/openmdx-${project.name}-models.zip"))
+    outputs.file(layout.buildDirectory.dir("generated/sources/model/openmdx-${project.name}.openmdx-xmi.zip"))
     classpath(configurations["openmdxBootstrap"])
     classpath(sourceSets["openmdxDatatype"].runtimeClasspath)
 	args = listOf(
@@ -188,18 +188,18 @@ tasks.register<org.openmdx.gradle.GenerateModelsTask>("generate-model") {
     doLast {
         copy {
             from(
-                zipTree("${buildDir}/generated/sources/model/openmdx-${project.name}-models.zip")
+                zipTree(layout.buildDirectory.dir("generated/sources/model/openmdx-${project.name}-models.zip"))
             )
-            into("${buildDir}/generated/sources/java/main")
+            into(layout.buildDirectory.dir("generated/sources/java/main"))
             include(
                 "**/*.java"
             )
         }
         copy {
             from(
-                zipTree("${buildDir}/generated/sources/model/openmdx-${project.name}.openmdx-xmi.zip")
+                zipTree(layout.buildDirectory.dir("generated/sources/model/openmdx-${project.name}.openmdx-xmi.zip"))
             )
-            into("${buildDir}/generated/resources/main")
+            into(layout.buildDirectory.dir("generated/resources/main"))
         }
     }
 }

--- a/test-core/build.gradle.kts
+++ b/test-core/build.gradle.kts
@@ -43,10 +43,8 @@
  * listed in the NOTICE file.
  */
 
-import org.gradle.kotlin.dsl.*
-import org.w3c.dom.Element
+import java.io.FileInputStream
 import java.util.*
-import java.io.*
 
 plugins {
 	java
@@ -82,7 +80,7 @@ fun getProjectImplementationVersion(): String {
 }
 
 fun getDeliverDir(): File {
-	return File(project.getRootDir(), "jre-" + targetPlatform + "/" + project.getName());
+	return File(project.getRootDir(), "jre-" + targetPlatform + "/" + project.name);
 }
 
 fun touch(file: File) {
@@ -162,8 +160,8 @@ tasks.register<org.openmdx.gradle.GenerateModelsTask>("generate-model") {
 	dependsOn("openmdxDatatypeClasses")
     inputs.dir("${projectDir}/src/model/emf")
     inputs.dir("${projectDir}/src/main/resources")
-    outputs.file("${buildDir}/generated/sources/model/openmdx-" + project.getName() + "-models.zip")
-    outputs.file("${buildDir}/generated/sources/model/openmdx-" + project.getName() + ".openmdx-xmi.zip")
+    outputs.file("${buildDir}/generated/sources/model/openmdx-" + project.name + "-models.zip")
+    outputs.file("${buildDir}/generated/sources/model/openmdx-" + project.name + ".openmdx-xmi.zip")
     classpath(configurations["openmdxBootstrap"])
     classpath(sourceSets["openmdxDatatype"].runtimeClasspath)
 	args = listOf(
@@ -175,7 +173,7 @@ tasks.register<org.openmdx.gradle.GenerateModelsTask>("generate-model") {
 		"--pathMapPath=file:" + File(project.getRootDir(), "portal/src/model/emf") + "/",
 		"--url=file:src/model/emf/models.uml",
 		"--xmi=emf",
-		"--out=" + File(project.getBuildDir(), "generated/sources/model/openmdx-" + project.getName() + "-models.zip"),
+		"--out=" + File(project.getBuildDir(), "generated/sources/model/openmdx-" + project.name + "-models.zip"),
 		"--openmdxjdo=" + File(project.getProjectDir(), "src/main/resources"),
 		"--dataproviderVersion=2",
 		"--format=xmi1",
@@ -190,7 +188,7 @@ tasks.register<org.openmdx.gradle.GenerateModelsTask>("generate-model") {
     doLast {
         copy {
             from(
-                zipTree("${buildDir}/generated/sources/model/openmdx-" + project.getName() + "-models.zip")
+                zipTree("${buildDir}/generated/sources/model/openmdx-" + project.name + "-models.zip")
             )
             into("${buildDir}/generated/sources/java/main")
             include(
@@ -199,7 +197,7 @@ tasks.register<org.openmdx.gradle.GenerateModelsTask>("generate-model") {
         }
         copy {
             from(
-                zipTree("${buildDir}/generated/sources/model/openmdx-" + project.getName() + ".openmdx-xmi.zip")
+                zipTree("${buildDir}/generated/sources/model/openmdx-" + project.name + ".openmdx-xmi.zip")
             )
             into("${buildDir}/generated/resources/main")
         }
@@ -221,17 +219,17 @@ tasks {
 
 distributions {
     main {
-    	distributionBaseName.set("openmdx-" + getProjectImplementationVersion() + "-" + project.getName() + "-jre-" + targetPlatform)
+    	distributionBaseName.set("openmdx-" + getProjectImplementationVersion() + "-" + project.name + "-jre-" + targetPlatform)
         contents {
         	// test-core
-        	from(".") { into(project.getName()); include("LICENSE", "*.LICENSE", "NOTICE", "*.properties", "build*.*", "*.xml", "*.kts") }
-            from("src") { into(project.getName() + "/src") }
+        	from(".") { into(project.name); include("LICENSE", "*.LICENSE", "NOTICE", "*.properties", "build*.*", "*.xml", "*.kts") }
+            from("src") { into(project.name + "/src") }
             // etc
-            from("etc") { into(project.getName() + "/etc") }
+            from("etc") { into(project.name + "/etc") }
             // rootDir
             from("..") { include("*.properties", "*.kts" ) }
             // jre-...
-            from("../jre-" + targetPlatform + "/" + project.getName() + "/lib") { into("jre-" + targetPlatform + "/" + project.getName() + "/lib") }
+            from("../jre-" + targetPlatform + "/" + project.name + "/lib") { into("jre-" + targetPlatform + "/" + project.name + "/lib") }
             from("../jre-" + targetPlatform + "/gradle/repo") { into("jre-" + targetPlatform + "/gradle/repo") }
         }
     }

--- a/test-security/build.gradle.kts
+++ b/test-security/build.gradle.kts
@@ -145,8 +145,8 @@ tasks {
 	assemble {
 		dependsOn()
 	}
-    named("processResources", Copy::class.java) { duplicatesStrategy = DuplicatesStrategy.WARN }
-    named("processTestResources", Copy::class.java) { duplicatesStrategy = DuplicatesStrategy.WARN }
+    named("processResources", Copy::class.java) { duplicatesStrategy = DuplicatesStrategy.EXCLUDE }
+    named("processTestResources", Copy::class.java) { duplicatesStrategy = DuplicatesStrategy.EXCLUDE }
 }
 
 distributions {

--- a/test-security/build.gradle.kts
+++ b/test-security/build.gradle.kts
@@ -42,10 +42,8 @@
  * This product includes software developed by other organizations as
  * listed in the NOTICE file.
  */
-import org.gradle.kotlin.dsl.*
-import org.w3c.dom.Element
+import java.io.FileInputStream
 import java.util.*
-import java.io.*
 
 plugins {
 	java
@@ -84,7 +82,7 @@ fun getProjectImplementationVersion(): String {
 }
 
 fun getDeliverDir(): File {
-	return File(project.getRootDir(), "jre-" + targetPlatform + "/" + project.getName());
+	return File(project.getRootDir(), "jre-" + targetPlatform + "/" + project.name);
 }
 
 fun touch(file: File) {
@@ -151,17 +149,17 @@ tasks {
 
 distributions {
     main {
-    	distributionBaseName.set("openmdx-" + getProjectImplementationVersion() + "-" + project.getName() + "-jre-" + targetPlatform)
+    	distributionBaseName.set("openmdx-" + getProjectImplementationVersion() + "-" + project.name + "-jre-" + targetPlatform)
         contents {
         	// test-core
-        	from(".") { into(project.getName()); include("LICENSE", "*.LICENSE", "NOTICE", "*.properties", "build*.*", "*.xml", "*.kts") }
-            from("src") { into(project.getName() + "/src") }
+        	from(".") { into(project.name); include("LICENSE", "*.LICENSE", "NOTICE", "*.properties", "build*.*", "*.xml", "*.kts") }
+            from("src") { into(project.name + "/src") }
             // etc
-            from("etc") { into(project.getName() + "/etc") }
+            from("etc") { into(project.name + "/etc") }
             // rootDir
             from("..") { include("*.properties", "*.kts" ) }
             // jre-...
-            from("../jre-" + targetPlatform + "/" + project.getName() + "/lib") { into("jre-" + targetPlatform + "/" + project.getName() + "/lib") }
+            from("../jre-" + targetPlatform + "/" + project.name + "/lib") { into("jre-" + targetPlatform + "/" + project.name + "/lib") }
             from("../jre-" + targetPlatform + "/gradle/repo") { into("jre-" + targetPlatform + "/gradle/repo") }
         }
     }

--- a/test-security/build.gradle.kts
+++ b/test-security/build.gradle.kts
@@ -63,7 +63,7 @@ repositories {
 }
 
 var env = Properties()
-env.load(FileInputStream(File(project.getRootDir(), "build.properties")))
+env.load(FileInputStream(File(project.rootDir, "build.properties")))
 val targetPlatform = JavaVersion.valueOf(env.getProperty("target.platform"))
 
 eclipse {
@@ -73,23 +73,23 @@ eclipse {
     jdt {
 		sourceCompatibility = targetPlatform
     	targetCompatibility = targetPlatform
-    	javaRuntimeName = "JavaSE-" + targetPlatform    	
+    	javaRuntimeName = "JavaSE-$targetPlatform"
     }
 }
 
 fun getProjectImplementationVersion(): String {
-	return project.getVersion().toString();
+	return project.version.toString();
 }
 
 fun getDeliverDir(): File {
-	return File(project.getRootDir(), "jre-" + targetPlatform + "/" + project.name);
+	return File(project.rootDir, "jre-" + targetPlatform + "/" + project.name);
 }
 
 fun touch(file: File) {
 	ant.withGroovyBuilder { "touch"("file" to file, "mkdirs" to true) }
 }
 
-project.getConfigurations().maybeCreate("openmdxBootstrap")
+project.configurations.maybeCreate("openmdxBootstrap")
 val openmdxBootstrap by configurations
 
 dependencies {
@@ -119,7 +119,7 @@ sourceSets {
         }
         resources {
         	srcDir("src/main/resources")
-        }        
+        }
     }
     test {
         java {
@@ -129,7 +129,7 @@ sourceSets {
         resources {
         	srcDir("src/test/resources")
         }
-    }    
+    }
 }
 
 tasks {
@@ -138,7 +138,7 @@ tasks {
 	    maxHeapSize = "4G"
 	}
 	compileJava {
-	    options.release.set(Integer.valueOf(targetPlatform.getMajorVersion()))
+	    options.release.set(Integer.valueOf(targetPlatform.majorVersion))
 	}
 	assemble {
 		dependsOn()
@@ -149,7 +149,7 @@ tasks {
 
 distributions {
     main {
-    	distributionBaseName.set("openmdx-" + getProjectImplementationVersion() + "-" + project.name + "-jre-" + targetPlatform)
+    	distributionBaseName.set("openmdx-" + getProjectImplementationVersion() + "-${project.name}-jre-" + targetPlatform)
         contents {
         	// test-core
         	from(".") { into(project.name); include("LICENSE", "*.LICENSE", "NOTICE", "*.properties", "build*.*", "*.xml", "*.kts") }
@@ -159,8 +159,10 @@ distributions {
             // rootDir
             from("..") { include("*.properties", "*.kts" ) }
             // jre-...
-            from("../jre-" + targetPlatform + "/" + project.name + "/lib") { into("jre-" + targetPlatform + "/" + project.name + "/lib") }
-            from("../jre-" + targetPlatform + "/gradle/repo") { into("jre-" + targetPlatform + "/gradle/repo") }
+            var path = "jre-$targetPlatform/${project.name}/lib"
+            from("../$path") { into(path) }
+            path = "jre-$targetPlatform/gradle/repo"
+            from("../$path") { into(path) }
         }
     }
 }

--- a/test-security/build.gradle.kts
+++ b/test-security/build.gradle.kts
@@ -115,7 +115,7 @@ sourceSets {
     main {
         java {
             srcDir("src/main/java")
-            srcDir("$buildDir/generated/sources/java/main")
+            srcDir(layout.buildDirectory.dir("generated/sources/java/main"))
         }
         resources {
         	srcDir("src/main/resources")
@@ -124,7 +124,7 @@ sourceSets {
     test {
         java {
             srcDir("src/test/java")
-            srcDir("$buildDir/generated/sources/java/test")
+            srcDir(layout.buildDirectory.dir("generated/sources/java/test"))
         }
         resources {
         	srcDir("src/test/resources")

--- a/tomcat/build.gradle.kts
+++ b/tomcat/build.gradle.kts
@@ -102,7 +102,7 @@ sourceSets {
     main {
         java {
             srcDir("src/main/java")
-            srcDir("$buildDir/generated/sources/java/main")
+            srcDir(layout.buildDirectory.dir("generated/sources/java/main"))
         }
         resources {
         	srcDir("src/main/resources")
@@ -111,7 +111,7 @@ sourceSets {
     test {
         java {
             srcDir("src/test/java")
-            srcDir("$buildDir/generated/sources/java/test")
+            srcDir(layout.buildDirectory.dir("generated/sources/java/test"))
         }
         resources {
         	srcDir("src/test/resources")
@@ -168,8 +168,8 @@ tasks {
 	        )
 	    }
 		from(
-			File(buildDir, "classes/java/main"),
-			File(buildDir, "resources/main"),
+			File(buildDirAsFile, "classes/java/main"),
+			File(buildDirAsFile, "resources/main"),
 			"src/main/resources"
 		)
 		include(openmdxCatalinaIncludes)
@@ -189,7 +189,7 @@ tasks {
 	    }
 		from(
 			"src/main/java",
-			File(buildDir, "generated/sources/java/main")
+			File(buildDirAsFile, "generated/sources/java/main")
 		)
 		include(openmdxCatalinaIncludes)
 		exclude(openmdxCatalinaExcludes)

--- a/tomcat/build.gradle.kts
+++ b/tomcat/build.gradle.kts
@@ -43,10 +43,8 @@
  * listed in the NOTICE file.
  */
 
-import org.gradle.kotlin.dsl.*
-import org.w3c.dom.Element
+import java.io.FileInputStream
 import java.util.*
-import java.io.*
 
 plugins {
 	java
@@ -82,7 +80,7 @@ fun getProjectImplementationVersion(): String {
 }
 
 fun getDeliverDir(): File {
-	return File(project.getRootDir(), "jre-" + targetPlatform + "/" + project.getName());
+	return File(project.getRootDir(), "jre-" + targetPlatform + "/" + project.name);
 }
 
 fun touch(file: File) {
@@ -200,17 +198,17 @@ tasks {
 
 distributions {
     main {
-    	distributionBaseName.set("openmdx-" + getProjectImplementationVersion() + "-" + project.getName() + "-jre-" + targetPlatform)
+    	distributionBaseName.set("openmdx-" + getProjectImplementationVersion() + "-" + project.name + "-jre-" + targetPlatform)
         contents {
         	// test-core
-        	from(".") { into(project.getName()); include("LICENSE", "*.LICENSE", "NOTICE", "*.properties", "build*.*", "*.xml", "*.kts") }
-            from("src") { into(project.getName() + "/src") }
+        	from(".") { into(project.name); include("LICENSE", "*.LICENSE", "NOTICE", "*.properties", "build*.*", "*.xml", "*.kts") }
+            from("src") { into(project.name + "/src") }
             // etc
-            from("etc") { into(project.getName() + "/etc") }
+            from("etc") { into(project.name + "/etc") }
             // rootDir
             from("..") { include("*.properties", "*.kts" ) }
             // jre-...
-            from("../jre-" + targetPlatform + "/" + project.getName() + "/lib") { into("jre-" + targetPlatform + "/" + project.getName() + "/lib") }
+            from("../jre-" + targetPlatform + "/" + project.name + "/lib") { into("jre-" + targetPlatform + "/" + project.name + "/lib") }
             from("../jre-" + targetPlatform + "/gradle/repo") { into("jre-" + targetPlatform + "/gradle/repo") }
         }
     }

--- a/tomcat/build.gradle.kts
+++ b/tomcat/build.gradle.kts
@@ -61,7 +61,7 @@ repositories {
 }
 
 var env = Properties()
-env.load(FileInputStream(File(project.getRootDir(), "build.properties")))
+env.load(FileInputStream(File(project.rootDir, "build.properties")))
 val targetPlatform = JavaVersion.valueOf(env.getProperty("target.platform"))
 
 eclipse {
@@ -71,23 +71,23 @@ eclipse {
     jdt {
 		sourceCompatibility = targetPlatform
     	targetCompatibility = targetPlatform
-    	javaRuntimeName = "JavaSE-" + targetPlatform    	
+    	javaRuntimeName = "JavaSE-$targetPlatform"
     }
 }
 
 fun getProjectImplementationVersion(): String {
-	return project.getVersion().toString();
+	return project.version.toString();
 }
 
 fun getDeliverDir(): File {
-	return File(project.getRootDir(), "jre-" + targetPlatform + "/" + project.name);
+	return File(project.rootDir, "jre-" + targetPlatform + "/" + project.name);
 }
 
 fun touch(file: File) {
 	ant.withGroovyBuilder { "touch"("file" to file, "mkdirs" to true) }
 }
 
-project.getConfigurations().maybeCreate("openmdxBootstrap")
+project.configurations.maybeCreate("openmdxBootstrap")
 val openmdxBootstrap by configurations
 
 dependencies {
@@ -106,7 +106,7 @@ sourceSets {
         }
         resources {
         	srcDir("src/main/resources")
-        }        
+        }
     }
     test {
         java {
@@ -116,7 +116,7 @@ sourceSets {
         resources {
         	srcDir("src/test/resources")
         }
-    }    
+    }
 }
 
 val openmdxCatalinaIncludes = listOf(
@@ -131,7 +131,7 @@ tasks {
 	    maxHeapSize = "4G"
 	}
 	compileJava {
- 	   options.release.set(Integer.valueOf(targetPlatform.getMajorVersion()))
+ 	   options.release.set(Integer.valueOf(targetPlatform.majorVersion))
 	}
 	assemble {
 		dependsOn(
@@ -198,7 +198,7 @@ tasks {
 
 distributions {
     main {
-    	distributionBaseName.set("openmdx-" + getProjectImplementationVersion() + "-" + project.name + "-jre-" + targetPlatform)
+    	distributionBaseName.set("openmdx-" + getProjectImplementationVersion() + "-${project.name}-jre-" + targetPlatform)
         contents {
         	// test-core
         	from(".") { into(project.name); include("LICENSE", "*.LICENSE", "NOTICE", "*.properties", "build*.*", "*.xml", "*.kts") }
@@ -208,8 +208,10 @@ distributions {
             // rootDir
             from("..") { include("*.properties", "*.kts" ) }
             // jre-...
-            from("../jre-" + targetPlatform + "/" + project.name + "/lib") { into("jre-" + targetPlatform + "/" + project.name + "/lib") }
-            from("../jre-" + targetPlatform + "/gradle/repo") { into("jre-" + targetPlatform + "/gradle/repo") }
+			var path = "jre-$targetPlatform/${project.name}/lib"
+			from("../$path") { into(path) }
+			path = "jre-$targetPlatform/gradle/repo"
+			from("../$path") { into(path) }
         }
     }
 }


### PR DESCRIPTION
Fixes #98 Previously, `orm.xml` wouldn't be included under `META-INF` in `openmdx-base.jar` on the first build (but it was getting included on subsequent builds!!). The exact same behaviour, however, was observed with some older versions, even prior to `2.18.8`.
Additionally, duplication of included resource files is prevented in the above mentioned `META-INF` in `openmdx-base.jar`, and some Gradle deprecations were fixed and others improved.